### PR TITLE
Support K5 parameters and delivered Technical Service #322

### DIFF
--- a/oscm-app-openstack-unittests/javasrc/org/oscm/app/openstack/controller/PropertyHandlerTest.java
+++ b/oscm-app-openstack-unittests/javasrc/org/oscm/app/openstack/controller/PropertyHandlerTest.java
@@ -61,22 +61,40 @@ public class PropertyHandlerTest {
 
         // case 1
         parameters.put(PropertyHandler.TEMPLATE_NAME, "template1.json");
-        configSettings.put(PropertyHandler.TEMPLATE_BASE_URL, "http://test.com");
+        configSettings.put(PropertyHandler.TEMPLATE_BASE_URL,
+                "http://test.com");
         propertyHandler = new PropertyHandler(settings);
         String url = propertyHandler.getTemplateUrl();
         assertEquals("http://test.com/template1.json", url);
 
         // case 2
-        parameters.put(PropertyHandler.TEMPLATE_NAME, "https://other.com/template1.json");
+        parameters.put(PropertyHandler.TEMPLATE_NAME,
+                "https://other.com/template1.json");
         url = propertyHandler.getTemplateUrl();
         assertEquals("https://other.com/template1.json", url);
 
         // case 3
-        configSettings.put(PropertyHandler.TEMPLATE_BASE_URL, "http://test.com/templates");
+        configSettings.put(PropertyHandler.TEMPLATE_BASE_URL,
+                "http://test.com/templates");
         parameters.put(PropertyHandler.TEMPLATE_NAME, "templates/apache.json");
         url = propertyHandler.getTemplateUrl();
         assertEquals("http://test.com/templates/apache.json", url);
 
+        // case 4
+        parameters.put(PropertyHandler.TEMPLATE_BASE_URL, "");
+        url = propertyHandler.getTemplateUrl();
+        assertEquals("http://test.com/templates/apache.json", url);
+    }
+
+    @Test()
+    public void testGetTemplateURL_onlyParam() throws HeatException {
+
+        // case 1
+        parameters.put(PropertyHandler.TEMPLATE_NAME, "template1.json");
+        parameters.put(PropertyHandler.TEMPLATE_BASE_URL, "http://test.com");
+        propertyHandler = new PropertyHandler(settings);
+        String url = propertyHandler.getTemplateUrl();
+        assertEquals("http://test.com/template1.json", url);
     }
 
     @Test()
@@ -111,6 +129,29 @@ public class PropertyHandlerTest {
         propertyHandler = new PropertyHandler(settings);
         String domainNameWithEmptyStr = propertyHandler.getDomainName();
         assertEquals("default", domainNameWithEmptyStr);
+    }
+
+    @Test()
+    public void testGetKeystoneURL() {
+        parameters.put(PropertyHandler.KEYSTONE_API_URL,
+                "http://keystone/v3/auth");
+        configSettings.put(PropertyHandler.KEYSTONE_API_URL,
+                "http://otherkeystone/v3/auth");
+        propertyHandler = new PropertyHandler(settings);
+        String keystoneURL = propertyHandler.getKeystoneUrl();
+        assertEquals("http://keystone/v3/auth", keystoneURL);
+    }
+
+    @Test()
+    public void testGetControllerKeystoneURL() {
+        configSettings.put(PropertyHandler.KEYSTONE_API_URL,
+                "http://otherkeystone/v3/auth");
+        propertyHandler = new PropertyHandler(settings);
+        String keystoneURL = propertyHandler.getKeystoneUrl();
+        assertEquals("http://otherkeystone/v3/auth", keystoneURL);
+        parameters.put(PropertyHandler.KEYSTONE_API_URL, "");
+        keystoneURL = propertyHandler.getKeystoneUrl();
+        assertEquals("http://otherkeystone/v3/auth", keystoneURL);
     }
 
     @Test()
@@ -172,22 +213,28 @@ public class PropertyHandlerTest {
 
     @Test
     public void testLocalizedResources() {
-        String messageEn = Messages.get("en", "status_" + FlowState.UPDATING.name());
-        String messageFr = Messages.get("fr", "status_" + FlowState.UPDATING.name());
+        String messageEn = Messages.get("en",
+                "status_" + FlowState.UPDATING.name());
+        String messageFr = Messages.get("fr",
+                "status_" + FlowState.UPDATING.name());
         assertTrue(messageEn.equals(messageFr));
     }
 
     @Test
     public void testArgsResources() {
-        String messageEn = Messages.get("en", "status_" + FlowState.UPDATING.name());
-        String messageEnParam = Messages.get("en", "status_" + FlowState.UPDATING.name(), "param 1");
+        String messageEn = Messages.get("en",
+                "status_" + FlowState.UPDATING.name());
+        String messageEnParam = Messages.get("en",
+                "status_" + FlowState.UPDATING.name(), "param 1");
         assertTrue(messageEn.equals(messageEnParam));
     }
 
     @Test
     public void testGetAllResources() {
-        List<LocalizedText> all = Messages.getAll("status_" + FlowState.UPDATING.name(), "testArg");
-        String messageEn = Messages.get("en", "status_" + FlowState.UPDATING.name());
+        List<LocalizedText> all = Messages
+                .getAll("status_" + FlowState.UPDATING.name(), "testArg");
+        String messageEn = Messages.get("en",
+                "status_" + FlowState.UPDATING.name());
         String found = null;
         for (LocalizedText test : all) {
             if ("en".equals(test.getLocale())) {
@@ -206,7 +253,8 @@ public class PropertyHandlerTest {
     @Test
     public void getMailForCompletion_empty() {
         String mailAddress = "";
-        propertyHandler.getSettings().getParameters().put(PropertyHandler.MAIL_FOR_COMPLETION, mailAddress);
+        propertyHandler.getSettings().getParameters()
+                .put(PropertyHandler.MAIL_FOR_COMPLETION, mailAddress);
         String mail = propertyHandler.getMailForCompletion();
         assertNull(mail);
     }
@@ -214,7 +262,8 @@ public class PropertyHandlerTest {
     @Test
     public void getMailForCompletion_notNull() {
         String mailAddress = "test@test.com";
-        propertyHandler.getSettings().getParameters().put(PropertyHandler.MAIL_FOR_COMPLETION, mailAddress);
+        propertyHandler.getSettings().getParameters()
+                .put(PropertyHandler.MAIL_FOR_COMPLETION, mailAddress);
         String mail = propertyHandler.getMailForCompletion();
         assertEquals(mailAddress, mail);
     }

--- a/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/PropertyHandler.java
+++ b/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/PropertyHandler.java
@@ -36,7 +36,8 @@ import org.slf4j.LoggerFactory;
  */
 public class PropertyHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PropertyHandler.class);
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(PropertyHandler.class);
 
     private final ProvisioningSettings settings;
 
@@ -174,7 +175,8 @@ public class PropertyHandler {
      * @return the access information pattern
      */
     public String getAccessInfoPattern() {
-        return getValidatedProperty(settings.getParameters(), ACCESS_INFO_PATTERN);
+        return getValidatedProperty(settings.getParameters(),
+                ACCESS_INFO_PATTERN);
     }
 
     /**
@@ -185,11 +187,18 @@ public class PropertyHandler {
     public String getTemplateUrl() throws HeatException {
 
         try {
-            String url = getValidatedProperty(settings.getParameters(), TEMPLATE_NAME);
-            String baseUrl = getValidatedProperty(settings.getConfigSettings(), TEMPLATE_BASE_URL);
+            String url = getValidatedProperty(settings.getParameters(),
+                    TEMPLATE_NAME);
+
+            String baseUrl = settings.getParameters().get(TEMPLATE_BASE_URL);
+            if (baseUrl == null || baseUrl.trim().length() == 0) {
+                baseUrl = getValidatedProperty(settings.getConfigSettings(),
+                        TEMPLATE_BASE_URL);
+            }
             return new URL(new URL(baseUrl), url).toExternalForm();
         } catch (MalformedURLException e) {
-            throw new HeatException("Cannot generate template URL: " + e.getMessage());
+            throw new HeatException(
+                    "Cannot generate template URL: " + e.getMessage());
         }
     }
 
@@ -217,11 +226,14 @@ public class PropertyHandler {
         for (String key : keySet) {
             if (key.startsWith(TEMPLATE_PARAMETER_PREFIX)) {
                 try {
-                    parameters.put(key.substring(TEMPLATE_PARAMETER_PREFIX.length()),
+                    parameters.put(
+                            key.substring(TEMPLATE_PARAMETER_PREFIX.length()),
                             settings.getParameters().get(key));
                 } catch (JSONException e) {
                     // should not happen with Strings
-                    throw new RuntimeException("JSON error when collection template parameters", e);
+                    throw new RuntimeException(
+                            "JSON error when collection template parameters",
+                            e);
                 }
             }
         }
@@ -238,10 +250,12 @@ public class PropertyHandler {
      *            The key to retrieve the setting for
      * @return the parameter value corresponding to the provided key
      */
-    private String getValidatedProperty(Map<String, String> sourceProps, String key) {
+    private String getValidatedProperty(Map<String, String> sourceProps,
+            String key) {
         String value = sourceProps.get(key);
         if (value == null) {
-            String message = String.format("No value set for property '%s'", key);
+            String message = String.format("No value set for property '%s'",
+                    key);
             LOGGER.error(message);
             throw new RuntimeException(message);
         }
@@ -255,7 +269,13 @@ public class PropertyHandler {
      * @return the Keystone URL
      */
     public String getKeystoneUrl() {
-        return getValidatedProperty(settings.getConfigSettings(), KEYSTONE_API_URL);
+
+        String keystoneURL = settings.getParameters().get(KEYSTONE_API_URL);
+        if (keystoneURL == null || keystoneURL.trim().length() == 0) {
+            keystoneURL = getValidatedProperty(settings.getConfigSettings(),
+                    KEYSTONE_API_URL);
+        }
+        return keystoneURL;
     }
 
     /**
@@ -317,7 +337,8 @@ public class PropertyHandler {
      * Returns service interfaces for BSS web service calls.
      */
     public <T> T getWebService(Class<T> serviceClass) throws Exception {
-        return BSSWebServiceFactory.getBSSWebService(serviceClass, settings.getAuthentication());
+        return BSSWebServiceFactory.getBSSWebService(serviceClass,
+                settings.getAuthentication());
     }
 
     /**

--- a/oscm-app-openstack/resources/TechnicalService_K5.xml
+++ b/oscm-app-openstack/resources/TechnicalService_K5.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright FUJITSU LIMITED 2016-->
+
+<tns:TechnicalServices xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="oscm.serviceprovisioning/1.9/TechnicalService.xsd ../../oscm-serviceprovisioning/javares/TechnicalServices.xsd"
+  xmlns:tns="oscm.serviceprovisioning/1.9/TechnicalService.xsd">
+  <tns:TechnicalService accessType="DIRECT" allowingOnBehalfActing="false" baseUrl=""
+    build="20140708" id="K5" loginPath=""
+    onlyOneSubscriptionPerUser="false" provisioningType="ASYNCHRONOUS"
+    provisioningUrl="https://<host>:<port>/ProvisioningService/AsynchronousProvisioningProxy?wsdl"
+    provisioningVersion="1.0">
+    <AccessInfo locale="en" >K5 Access Info.</AccessInfo>
+    <LocalizedDescription locale="en">K5 IaaS implementation.</LocalizedDescription>
+    <LocalizedLicense locale="en" />
+    <LocalizedTag locale="en">K5</LocalizedTag>
+    <ParameterDefinition configurable="false" default="ess.openstack" id="APP_CONTROLLER_ID" mandatory="true"
+      valueType="STRING">
+      <LocalizedDescription locale="en">The ID of the BSS APP based controller implementation.</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="STACK_NAME" default="" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Stack name</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" default="([A-Za-z][A-Za-z0-9_-]*){1,30}" id="STACK_NAME_PATTERN"
+      modificationType="ONE_TIME" mandatory="true" valueType="STRING">
+      <LocalizedDescription locale="en">Validation pattern for stack name (regex)</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TEMPLATE_BASE_URL" default="<template URL>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Template base URL</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TEMPLATE_NAME" default="template_k5.yaml" mandatory="true"
+      valueType="ENUMERATION" modificationType="ONE_TIME">
+      <Options>
+        <Option id="template_k5.yaml">
+          <LocalizedOption locale="en">template_k5.yaml</LocalizedOption>
+        </Option>
+      </Options>
+      <LocalizedDescription locale="en">URL of the template schema</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TENANT_ID" default="<your.tenant.id>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Project ID</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="DOMAIN_NAME" default="<your.contract.no>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Contracct No.</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="KEYSTONE_API_URL" default="https://identity.jp-east-1.cloud.global.fujitsu.com/v3/auth" mandatory="true"
+      valueType="ENUMERATION" modificationType="ONE_TIME">
+      <Options>
+        <Option id="https://identity.jp-east-1.cloud.global.fujitsu.com/v3/auth">
+          <LocalizedOption locale="en">jp-east-1</LocalizedOption>
+        </Option>
+        <Option id="https://identity.jp-west-1.cloud.global.fujitsu.com/v3/auth">
+          <LocalizedOption locale="en">jp-west-1</LocalizedOption>
+        </Option>
+        <Option id="https://identity.jp-west-2.cloud.global.fujitsu.com/v3/auth">
+          <LocalizedOption locale="en">jp-west-2</LocalizedOption>
+        </Option>
+        <Option id="https://identity.jp-uk-1.cloud.global.fujitsu.com/v3/auth">
+          <LocalizedOption locale="en">jp-uk-1</LocalizedOption>
+        </Option>
+      </Options>
+      <LocalizedDescription locale="en">Region</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="ACCESS_INFO_PATTERN" default="Key pair name for vm1: {KP_Out}; Ip for vm1: {IP_Out}; Key pair name for vm2: {KP_Out2}; Ip for vm2: {IP_Out2}" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Pattern for access information</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_ImageId" default="cedarish" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Image Id</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_flavor" default="S-1" mandatory="true"
+      valueType="ENUMERATION" modificationType="ONE_TIME">
+      <Options>
+        <Option id="P-1">
+          <LocalizedOption locale="en">P-1</LocalizedOption>
+        </Option>
+        <Option id="T-1">
+          <LocalizedOption locale="en">T-1</LocalizedOption>
+        </Option>
+        <Option id="C-1">
+          <LocalizedOption locale="en">C-1</LocalizedOption>
+        </Option>
+        <Option id="C-2">
+          <LocalizedOption locale="en">C-2</LocalizedOption>
+        </Option>
+        <Option id="C-4">
+          <LocalizedOption locale="en">C-4</LocalizedOption>
+        </Option>
+        <Option id="C-8">
+          <LocalizedOption locale="en">C-8</LocalizedOption>
+        </Option>
+        <Option id="C-16">
+          <LocalizedOption locale="en">C-16</LocalizedOption>
+        </Option>
+        <Option id="S-1">
+          <LocalizedOption locale="en">S-1</LocalizedOption>
+        </Option>
+        <Option id="S-2">
+          <LocalizedOption locale="en">S-2</LocalizedOption>
+        </Option>
+        <Option id="S-4">
+          <LocalizedOption locale="en">S-4</LocalizedOption>
+        </Option>
+        <Option id="S-8">
+          <LocalizedOption locale="en">S-8</LocalizedOption>
+        </Option>
+        <Option id="S-16">
+          <LocalizedOption locale="en">S-16</LocalizedOption>
+        </Option>
+        <Option id="M-1">
+          <LocalizedOption locale="en">M-1</LocalizedOption>
+        </Option>
+        <Option id="M-2">
+          <LocalizedOption locale="en">M-2</LocalizedOption>
+        </Option>
+        <Option id="M-4">
+          <LocalizedOption locale="en">M-4</LocalizedOption>
+        </Option>
+        <Option id="M-8">
+          <LocalizedOption locale="en">M-8</LocalizedOption>
+        </Option>
+        <Option id="M-16">
+          <LocalizedOption locale="en">M-16</LocalizedOption>
+        </Option>
+        <Option id="XM-4">
+          <LocalizedOption locale="en">XM-4</LocalizedOption>
+        </Option>
+
+      </Options>
+      <LocalizedDescription locale="en">Instance type</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_KeyName" default="<your.keypair.name>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Key name</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_network" default="<your.network.uuid>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Internal network uuid</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_sg_name" default="<your.security.group.name>" mandatory="true" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">Security group name</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="true" id="TP_az" default="jp-east-1a" mandatory="true"
+      valueType="ENUMERATION" modificationType="ONE_TIME">
+      <Options>
+        <Option id="jp-east-1a">
+          <LocalizedOption locale="en">jp-east-1a</LocalizedOption>
+        </Option>
+        <Option id="jp-east-1b">
+          <LocalizedOption locale="en">jp-east-1b</LocalizedOption>
+        </Option>
+        <Option id="jp-west-1a">
+          <LocalizedOption locale="en">jp-west-1a</LocalizedOption>
+        </Option>
+        <Option id="jp-west-1b">
+          <LocalizedOption locale="en">jp-west-1b</LocalizedOption>
+        </Option>
+        <Option id="jp-west-2a">
+          <LocalizedOption locale="en">jp-west-2a</LocalizedOption>
+        </Option>
+        <Option id="jp-west-2b">
+          <LocalizedOption locale="en">jp-west-2b</LocalizedOption>
+        </Option>
+        <Option id="uk-1a">
+          <LocalizedOption locale="en">uk-1a</LocalizedOption>
+        </Option>
+        <Option id="uk-1b">
+          <LocalizedOption locale="en">uk-1b</LocalizedOption>
+        </Option>
+      </Options>
+      <LocalizedDescription locale="en">Availability Zone</LocalizedDescription>
+    </ParameterDefinition>
+    <ParameterDefinition configurable="false" id="MAIL_FOR_COMPLETION" default="<your.mail>"
+      mandatory="false" valueType="STRING" modificationType="ONE_TIME">
+      <LocalizedDescription locale="en">The address to which emails are to be sent that describe manual steps required to complete an operation. If you specify this parameter, the service controller interrupts the processing of each operation before its completion and waits for a notification about the execution of a manual action. Omit this parameter if you do not want to interrupt the processing.</LocalizedDescription>
+      <LocalizedDescription locale="ja">操作を完了するために手動の手順が必要であることを知らせるemailの送信先メールアドレス。このパラメーターを指定すると、サービスコントロールは各操作の完了前に処理を中断して、手動の操作が終わったことを知らせる通知が届くまで待ちます。処理を中断したくない場合は、このパラメーターを省略してください。</LocalizedDescription>
+    </ParameterDefinition>
+    <Operation actionURL="https://<host>:<port>/OperationService/AsynchronousOperationProxy?wsdl" id="START_VIRTUAL_SYSTEM">
+      <LocalizedName locale="de">Start</LocalizedName>
+      <LocalizedName locale="en">Start</LocalizedName>
+      <LocalizedName locale="ja">起動</LocalizedName>
+      <LocalizedDescription locale="de">Startet die Instanz</LocalizedDescription>
+      <LocalizedDescription locale="en">Start the instance</LocalizedDescription>
+      <LocalizedDescription locale="ja">システムを起動します</LocalizedDescription>
+    </Operation>
+    <Operation actionURL="https://<host>:<port>/OperationService/AsynchronousOperationProxy?wsdl" id="STOP_VIRTUAL_SYSTEM">
+      <LocalizedName locale="de">Stop</LocalizedName>
+      <LocalizedName locale="en">Stop</LocalizedName>
+      <LocalizedName locale="ja">停止</LocalizedName>
+      <LocalizedDescription locale="de">Stoppt die Instanz</LocalizedDescription>
+      <LocalizedDescription locale="en">Stop the instance</LocalizedDescription>
+      <LocalizedDescription locale="ja">システムを停止します</LocalizedDescription>
+    </Operation>
+  </tns:TechnicalService>
+</tns:TechnicalServices>

--- a/oscm-app-openstack/resources/template_k5.yaml
+++ b/oscm-app-openstack/resources/template_k5.yaml
@@ -1,6 +1,6 @@
 heat_template_version: 2013-05-23
 
-description: The Heat Orchestration template used for the creation and provisioning of a stack. This template for FUJITSU Enterprise Cloud Service K5.
+description: This is a Heat Orchestration template used for the creation and provisioning of a stack in FUJITSU Enterprise Cloud Service K5.
 
 parameters:
   az:
@@ -34,7 +34,7 @@ resources:
     properties:
       size: 3
       volume_type: "M1"
-      availability_zone: { get_param: az}
+      availability_zone: {get_param: az}
       image: {get_param: ImageId}
 
   vm1:
@@ -44,7 +44,7 @@ resources:
       key_name: {get_param: KeyName}
       image: {get_param: ImageId}
       block_device_mapping: [{"volume_size": 3, "volume_id": {get_resource: Sys-vol}, "delete_on_termination": True, "device_name": "/dev/vda"}]
-      availability_zone: { get_param: az}
+      availability_zone: {get_param: az}
       networks: ["uuid": {get_param: network}]
       security_groups: [{get_param: sg_name}]
 
@@ -62,7 +62,7 @@ resources:
       flavor: {get_param: flavor}
       image: {get_param: ImageId}
       block_device_mapping: [{"volume_size": 3, "volume_id": {get_resource: Sys-vol2}, "delete_on_termination": True, "device_name": "/dev/vda"}]
-      availability_zone: { get_param: az}
+      availability_zone: {get_param: az}
       networks: ["uuid": {get_param: network}]
       security_groups: [{get_param: sg_name}]
       key_name: {get_param: KeyName}

--- a/oscm-app-openstack/resources/template_k5.yaml
+++ b/oscm-app-openstack/resources/template_k5.yaml
@@ -1,0 +1,82 @@
+heat_template_version: 2013-05-23
+
+description: The Heat Orchestration template used for the creation and provisioning of a stack. This template for FUJITSU Enterprise Cloud Service K5.
+
+parameters:
+  az:
+    type: string
+    description: availability zone
+    default: jp-west-1a
+  flavor:
+    type: string
+    description: flavor
+    default: P-1
+  ImageId:
+    description: The id of the image to provision.
+    type: string
+    default: <please input your image id>
+  KeyName:
+    description: The name of an already defined key pair in OpenStack, used for enabling SSH access to the web server.
+    type: string
+    default: <please input your keypair name>
+  network:
+    type: string
+    description: internal network uuid
+    default: <please input your internal network uuid>
+  sg_name:
+    type: string
+    description: security group
+    default: <please input your security group name>
+
+resources:
+  Sys-vol:
+    type: OS::Cinder::Volume
+    properties:
+      size: 3
+      volume_type: "M1"
+      availability_zone: { get_param: az}
+      image: {get_param: ImageId}
+
+  vm1:
+    type: OS::Nova::Server
+    properties:
+      flavor: {get_param: flavor}
+      key_name: {get_param: KeyName}
+      image: {get_param: ImageId}
+      block_device_mapping: [{"volume_size": 3, "volume_id": {get_resource: Sys-vol}, "delete_on_termination": True, "device_name": "/dev/vda"}]
+      availability_zone: { get_param: az}
+      networks: ["uuid": {get_param: network}]
+      security_groups: [{get_param: sg_name}]
+
+  Sys-vol2:
+    type: OS::Cinder::Volume
+    properties:
+      size: 3
+      volume_type: "M1"
+      availability_zone: { get_param: az}
+      image: {get_param: ImageId}
+
+  vm2:
+    type: OS::Nova::Server
+    properties:
+      flavor: {get_param: flavor}
+      image: {get_param: ImageId}
+      block_device_mapping: [{"volume_size": 3, "volume_id": {get_resource: Sys-vol2}, "delete_on_termination": True, "device_name": "/dev/vda"}]
+      availability_zone: { get_param: az}
+      networks: ["uuid": {get_param: network}]
+      security_groups: [{get_param: sg_name}]
+      key_name: {get_param: KeyName}
+
+outputs:
+  KP_Out:
+    description: Key pair name
+    value: {get_param: KeyName}
+  IP_Out:
+    description: IP Address of the access host
+    value: {get_attr: [vm1, networks, <your internal network name>, 0]}
+  KP_Out2:
+    description: Key pair name vm2
+    value: {get_param: KeyName}
+  IP_Out2:
+    description: IP Address of the access host
+    value: {get_attr: [vm2, networks, <your internal network name>, 0]}

--- a/oscm-converter/javares/TechnicalServices1_9.xsd
+++ b/oscm-converter/javares/TechnicalServices1_9.xsd
@@ -159,7 +159,7 @@
 			<xsd:element name="LocalizedOption" type="tns:LocalizedDescriptionType"
 				maxOccurs="unbounded" minOccurs="1" />
 		</xsd:sequence>
-		<xsd:attribute name="id" type="tns:StrId" use="required" />
+		<xsd:attribute name="id" type="tns:Str255" use="required" />
 	</xsd:complexType>
 
 	<xsd:complexType name="OperationType">

--- a/oscm-serviceprovisioning/javares/TechnicalServices.xsd
+++ b/oscm-serviceprovisioning/javares/TechnicalServices.xsd
@@ -159,7 +159,7 @@
 			<xsd:element name="LocalizedOption" type="tns:LocalizedDescriptionType"
 				maxOccurs="unbounded" minOccurs="1" />
 		</xsd:sequence>
-		<xsd:attribute name="id" type="tns:StrId" use="required" />
+		<xsd:attribute name="id" type="tns:Str255" use="required" />
 	</xsd:complexType>
 
 	<xsd:complexType name="OperationType">


### PR DESCRIPTION
Fix propertyHandler to set paramters to technial serivce and add sample TechnicalService and template for FUJITSU Enterprise Cloud Service K5.
This pull request is related to #322 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/development/376)
<!-- Reviewable:end -->
