### PR TITLE
hotfix/issue-767 - external parameter configurator no longer throws NPE

### DIFF
--- a/oscm-portal/javasrc/org/oscm/ui/dialog/mp/subscriptionwizard/SubscriptionWizardConversation.java
+++ b/oscm-portal/javasrc/org/oscm/ui/dialog/mp/subscriptionwizard/SubscriptionWizardConversation.java
@@ -554,7 +554,7 @@ public class SubscriptionWizardConversation implements Serializable {
     public String validateConfiguredParameters() {
         String validationResult = jsonValidator
                 .validateConfiguredParameters(model);
-        switch (validationResult) {
+        switch (validationResult == null ? "" : validationResult) {
         case OUTCOME_ERROR:
             addMessage(FacesMessage.SEVERITY_ERROR,
                     ERROR_EXTERNAL_TOOL_COMMUNICATION);
@@ -563,7 +563,7 @@ public class SubscriptionWizardConversation implements Serializable {
             addMessage(FacesMessage.SEVERITY_ERROR,
                     ERROR_INVALID_CONFIGURED_PARAMETERS);
         default:
-            return "";
+            return null;
         }
     }
 

--- a/oscm-portal/javasrc/org/oscm/ui/dialog/mp/subscriptionwizard/SubscriptionWizardConversation.java
+++ b/oscm-portal/javasrc/org/oscm/ui/dialog/mp/subscriptionwizard/SubscriptionWizardConversation.java
@@ -563,7 +563,7 @@ public class SubscriptionWizardConversation implements Serializable {
             addMessage(FacesMessage.SEVERITY_ERROR,
                     ERROR_INVALID_CONFIGURED_PARAMETERS);
         default:
-            return null;
+            return "";
         }
     }
 


### PR DESCRIPTION
Fixes #767 
I was able to configure a Marketable Service with the external configuration tool with no NPE in the logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/development/772)
<!-- Reviewable:end -->
