### PR TITLE
hotfix/issue-779

### DIFF
--- a/oscm-integrationtests-parameter-configurator/WebContent/scripts/configurationUi.js
+++ b/oscm-integrationtests-parameter-configurator/WebContent/scripts/configurationUi.js
@@ -106,15 +106,15 @@ BssParameterConfigurator.prototype = {
                 var optionIds = this._parameters[i].getOptionIds();
 	        for (var op=0; op < optionIds.length; op++) {
                     var currentOption = document.getElementById(this._parameters[i].getId() + ":option:" + optionIds[op]);
-                    if(currentOption.checked){
-                        totalPrice += this._parameters[i].getOptions()[op].pricePerSubscription;
+                    if(currentOption.checked) {
+                        totalPrice += (this._parameters[i].getOptions()[op].pricePerSubscription)*1000000;
                     }
                 }
-	    } else {
-                totalPrice += this._parameters[i].getPricePerSubscription();
-	    }
+	        } else {
+                totalPrice += (this._parameters[i].getPricePerSubscription())*1000000;
+	        }
         }
-        price.innerHTML = totalPrice;
+        price.innerHTML = totalPrice/1000000;
     },
 
     generateButtons : function() {


### PR DESCRIPTION
External configuration tool - precision raised to 0.000001 (one millionth) of a cent.
Error was due to low precision of JavaScript float type.
Solution is the recommended solution without bringing in new libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/development/798)
<!-- Reviewable:end -->
