### PR TITLE
Hotfix/issue 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - sudo pip install --user codecov
 install:
   - wget -P libraries/apache-ant-contrib/javalib/ http://central.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar
-  - wget -P libraries/apache-ant/ https://www.apache.org/dist/ant/binaries/apache-ant-1.10.1-bin.zip
-  - unzip -o -d libraries/apache-ant/ libraries/apache-ant/apache-ant-1.10.1-bin.zip
+  - wget -P libraries/apache-ant/ https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip 
+  - unzip -o -d libraries/apache-ant/ libraries/apache-ant/apache-ant-1.10.5-bin.zip
   - mkdir ../document
   - cd ../document
   - wget https://github.com/servicecatalog/documentation/archive/master.zip
@@ -25,7 +25,7 @@ env:
     - COMUPTERNAME=travis
     - HOSTNAME=travis
 script:
-  - $TRAVIS_BUILD_DIR/libraries/apache-ant/apache-ant-1.10.1/bin/ant -lib $TRAVIS_BUILD_DIR/libraries/apache-ant-contrib/javalib/ivy-2.4.0.jar:$TRAVIS_BUILD_DIR/parallel/build/libs/parallel-junit-0.1.jar -file $TRAVIS_BUILD_DIR/oscm-build/cruisecontrol.xml runTravisUT
+  - $TRAVIS_BUILD_DIR/libraries/apache-ant/apache-ant-1.10.5/bin/ant -lib $TRAVIS_BUILD_DIR/libraries/apache-ant-contrib/javalib/ivy-2.4.0.jar:$TRAVIS_BUILD_DIR/parallel/build/libs/parallel-junit-0.1.jar -file $TRAVIS_BUILD_DIR/oscm-build/cruisecontrol.xml runTravisUT
 #  - ant -lib $TRAVIS_BUILD_DIR/libraries/apache-ant-contrib/javalib -file $TRAVIS_BUILD_DIR/oscm-build/cruisecontrol.xml runTravisIT
 after_success:
   - sonar-scanner -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=CTMG -Dsonar.projectName=CTMG -Dsonar.projectVersion=17.0.1 -Dsonar.sources=$TRAVIS_BUILD_DIR -Dsonar.tests=$TRAVIS_BUILD_DIR -Dsonar.sourceEncoding=UTF-8 -Dsonar.inclusions=**/*.java -Dsonar.exclusions=**/javasrc-it/**,**/example-service/**/*,**/*devruntime/**/*,**/*tests*/**/*,**/oscm-portal-webtests/results/**/*,**/j2ep/**/*.java,**/apache-csv/**/*.java,**/*oscm-build*/**/*.java,**/javasrc-it/**/*.java,**/*unittests*/**/*.java,**/OperationParameterType.jav,**/AccountServiceClient.java -Dsonar.test.inclusions=**/*unittests*/**/*.java -Dsonar.jacoco.reportPath=$TRAVIS_BUILD_DIR/oscm-build/result/reports/merged_jacoco.exec -Dsonar.java.source=1.8 -Dsonar.java.binaries=$TRAVIS_BUILD_DIR/oscm-build/result/work -Dsonar.java.test.binaries=$TRAVIS_BUILD_DIR/oscm-build/result

--- a/oscm-build/build.xml
+++ b/oscm-build/build.xml
@@ -144,6 +144,7 @@
   </target>
 
   <target name="_copyDocument">
+  	<!--
     <copy todir="${workspace.dir}/oscm-app-aws/doc">
       <fileset dir="../../document/Development/oscm-app-aws/doc">
         <exclude name=".project"/>
@@ -197,6 +198,7 @@
         <exclude name=".project"/>
       </fileset>
     </copy>
+    -->
     <!--<copy todir="${workspace.dir}/UserDoc">-->
       <!--<fileset dir="../../document/Development/UserDoc" />-->
     <!--</copy>-->

--- a/oscm-common-unittests/javasrc/org/oscm/headers/HeadersTest.java
+++ b/oscm-common-unittests/javasrc/org/oscm/headers/HeadersTest.java
@@ -105,7 +105,7 @@ public class HeadersTest {
                         continue;
                     }
                     checkFile(fileName,
-                            "<!-- Copyright FUJITSU LIMITED 2017-->");
+                            "<!-- Copyright FUJITSU LIMITED 201");
                 } else if (fileName.toLowerCase().endsWith(".properties")) {
                     if (fileName.toLowerCase().contains(
                             "oscm-common-unittests" + java.io.File.separator

--- a/oscm-common-unittests/javasrc/org/oscm/headers/HeadersTest.java
+++ b/oscm-common-unittests/javasrc/org/oscm/headers/HeadersTest.java
@@ -97,7 +97,7 @@ public class HeadersTest {
                             || fileName.contains("import_en.css")) {
                         continue;
                     }
-                    checkFile(fileName, "*  Copyright FUJITSU LIMITED 2017");
+                    checkFile(fileName, "*  Copyright FUJITSU LIMITED 201");
                 } else if (fileName.toLowerCase().endsWith(".xml")
                         || fileName.toLowerCase().endsWith(".xhtml")) {
                     if (fileName
@@ -113,7 +113,7 @@ public class HeadersTest {
                             || fileName.contains("wt.testInWork.properties")) {
                         continue;
                     }
-                    checkFile(fileName, "# Copyright FUJITSU LIMITED 2017");
+                    checkFile(fileName, "# Copyright FUJITSU LIMITED 201");
                 }
             }
         }

--- a/oscm-devruntime/javares/local/estgoebel/integration.properties
+++ b/oscm-devruntime/javares/local/estgoebel/integration.properties
@@ -1,8 +1,8 @@
 # Copyright FUJITSU LIMITED 2017
 dbinterpreter=C:/PostgreSQL/9.3/bin/psql
 glassfish.home=C:/glassfish4
-keytool=C:/jdk1.7.0_45/jre/bin/keytool.exe
-bss.java.home=C:/jdk1.7.0_45
+keytool=C:/jdk1.8.0_131/jre/bin/keytool.exe
+bss.java.home=C:/jdk1.8.0_131
 apache.present=false
 
 #BES domain
@@ -32,7 +32,7 @@ glassfish.master.domain.host=estgoebel
 glassfish.master.domain.jms.port=8476
 
 #Hibernate search master properties
-master.slave.shared.hibernate.search.sourceBase=C\\:/glassfish3/masterSourceBase
+master.slave.shared.hibernate.search.sourceBase=C\\:/glassfish4/masterSourceBase
 master.hibernate.search.default.refresh=60
 
 #Example domain

--- a/oscm-identitymgmt-unittests/javasrc-it/org/oscm/identityservice/bean/IdentityServiceBeanIT.java
+++ b/oscm-identitymgmt-unittests/javasrc-it/org/oscm/identityservice/bean/IdentityServiceBeanIT.java
@@ -406,12 +406,31 @@ public class IdentityServiceBeanIT extends EJBTestBase {
         try {
             final String mail = "admin@organization.com";
             modifyUserData(mail, mail);
+            assertEquals(0, sendedMails.size());
+        } finally {
+            sendedMails.clear();
+        }
+    }
+    
+    @Test
+    public void testUpdateUser_NoEmail() throws Exception {
+        sendedMails.clear();
+        try {
+            final String mail = "admin@organization.com";
+            modifyUserData(null, mail);
             assertEquals(1, sendedMails.size());
             checkEmail(0, mail);
         } finally {
             sendedMails.clear();
         }
     }
+
+   
+    private void checkEmail(int i, String mail) {
+        checkEmail(i, mail, EmailType.USER_UPDATED); 
+    }
+    
+  
 
     private void modifyUserData(final String oldEmail, final String newEmail)
             throws Exception {
@@ -437,11 +456,11 @@ public class IdentityServiceBeanIT extends EJBTestBase {
         });
     }
 
-    private void checkEmail(int index, String expectedEmail) {
+    private void checkEmail(int index, String expectedEmail, EmailType expectedType) {
         assertEquals(expectedEmail,
                 sendedMails.get(index).getInstance().getEmail());
 
-        assertEquals(EmailType.USER_UPDATED,
+        assertEquals(expectedType,
                 sendedMails.get(index).getEmailType());
 
         assertNull(sendedMails.get(index).getParams());

--- a/oscm-identitymgmt-unittests/javasrc-it/org/oscm/identityservice/bean/IdentityServiceBeanIT.java
+++ b/oscm-identitymgmt-unittests/javasrc-it/org/oscm/identityservice/bean/IdentityServiceBeanIT.java
@@ -389,7 +389,7 @@ public class IdentityServiceBeanIT extends EJBTestBase {
             final String oldEmail = "admin@organization.com";
             final String newEmail = "enes.sejfi@est.fujitsu.com";
 
-            modifyUserData(oldEmail, newEmail);
+            modifyUserDataEmail(oldEmail, newEmail);
 
             assertEquals(2, sendedMails.size());
             checkEmail(0, newEmail);
@@ -405,19 +405,19 @@ public class IdentityServiceBeanIT extends EJBTestBase {
         sendedMails.clear();
         try {
             final String mail = "admin@organization.com";
-            modifyUserData(mail, mail);
+            modifyUserDataEmail(mail, mail);
             assertEquals(0, sendedMails.size());
         } finally {
             sendedMails.clear();
         }
     }
-    
+
     @Test
     public void testUpdateUser_NoEmail() throws Exception {
         sendedMails.clear();
         try {
             final String mail = "admin@organization.com";
-            modifyUserData(null, mail);
+            modifyUserDataEmail(null, mail);
             assertEquals(1, sendedMails.size());
             checkEmail(0, mail);
         } finally {
@@ -425,30 +425,60 @@ public class IdentityServiceBeanIT extends EJBTestBase {
         }
     }
 
-   
-    private void checkEmail(int i, String mail) {
-        checkEmail(i, mail, EmailType.USER_UPDATED); 
+    @Test
+    public void testUpdateUser_UserID() throws Exception {
+        sendedMails.clear();
+        try {
+            modifyUserDataUserId("admin", "admin123");
+            assertEquals(1, sendedMails.size());
+            checkEmail(0, givenUserDetails().getEMail());
+        } finally {
+            sendedMails.clear();
+        }
     }
     
-  
+    @Test
+    public void testUpdateUser_Address() throws Exception {
+        sendedMails.clear();
+        try {
+            modifyUserDataUserAddress();
+            assertEquals(1, sendedMails.size());
+            checkEmail(0, givenUserDetails().getEMail());
+        } finally {
+            sendedMails.clear();
+        }
+    }
 
-    private void modifyUserData(final String oldEmail, final String newEmail)
-            throws Exception {
+    
+    @Test
+    public void testUpdateUser_Phone() throws Exception {
+        sendedMails.clear();
+        try {
+            modifyUserDataPhone();
+            assertEquals(1, sendedMails.size());
+            checkEmail(0, givenUserDetails().getEMail());
+        } finally {
+            sendedMails.clear();
+        }
+    }
+    
+    private void checkEmail(int i, String mail) {
+        checkEmail(i, mail, EmailType.USER_UPDATED);
+    }
+
+    private void modifyUserDataEmail(final String oldEmail,
+            final String newEmail) throws Exception {
         runTX(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-                PlatformUser existingUser = new PlatformUser();
-                existingUser.setEmail(oldEmail);
-                existingUser.setLocale(Locale.GERMAN.toString());
+                VOUserDetails user = givenUserDetails();
+                user.setEMail(newEmail);
+
+                PlatformUser existingUser = UserDataAssembler
+                        .toPlatformUser(user);
                 existingUser.setOrganization(mgr.getReference(
                         Organization.class, organization.getKey()));
-                existingUser.setUserId("g");
-
-                VOUserDetails user = new VOUserDetails();
-                user.setUserId("g");
-                user.setEMail(newEmail);
-                user.setLocale(Locale.GERMAN.toString());
-                user.setOrganizationId(organization.getOrganizationId());
+                existingUser.setEmail(oldEmail);
 
                 idMgmtLocal.modifyUserData(existingUser, user, false, true);
                 return null;
@@ -456,12 +486,98 @@ public class IdentityServiceBeanIT extends EJBTestBase {
         });
     }
 
-    private void checkEmail(int index, String expectedEmail, EmailType expectedType) {
+    private void modifyUserDataUserId(final String oldId, final String newId)
+            throws Exception {
+        runTX(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+
+                VOUserDetails user = givenUserDetails();
+                user.setUserId(newId);
+                
+                PlatformUser existingUser = UserDataAssembler
+                        .toPlatformUser(user);
+                existingUser.setOrganization(mgr.getReference(
+                        Organization.class, organization.getKey()));
+                existingUser.setUserId(oldId);
+
+                idMgmtLocal.modifyUserData(existingUser, user, false, true);
+                return null;
+            }
+
+        });
+    }
+
+    private void modifyUserDataUserAddress() throws Exception {
+        runTX(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+
+                VOUserDetails user = givenUserDetails();
+                
+
+                PlatformUser existingUser = UserDataAssembler
+                        .toPlatformUser(user);
+                existingUser.setOrganization(mgr.getReference(
+                        Organization.class, organization.getKey()));
+                
+                existingUser.setAddress("1st Avenue\nNewtown 123");
+
+                idMgmtLocal.modifyUserData(existingUser, user, false, true);
+                return null;
+            }
+
+        });
+    }
+    
+    private void modifyUserDataPhone()
+            throws Exception {
+        runTX(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+
+                VOUserDetails user = givenUserDetails();
+
+                PlatformUser existingUser = UserDataAssembler
+                        .toPlatformUser(user);
+                existingUser.setOrganization(mgr.getReference(
+                        Organization.class, organization.getKey()));
+                existingUser.setPhone("555");
+
+                idMgmtLocal.modifyUserData(existingUser, user, false, true);
+                return null;
+            }
+
+        });
+    }
+
+    VOUserDetails givenUserDetails() {
+        return givenUserData("admin@organization.com", "g",
+                Locale.GERMAN.toString(), organization.getOrganizationId(),
+                "Donald", "Duck", "12345", "Street 123\n 333 Ducktown");
+    }
+
+    VOUserDetails givenUserData(String email, String userId, String locale,
+            String orgid, String firstName, String lastName, String phone,
+            String address) {
+        VOUserDetails user = new VOUserDetails();
+        user.setUserId(userId);
+        user.setEMail(email);
+        user.setLocale(locale);
+        user.setOrganizationId(orgid);
+        user.setPhone(phone);
+        user.setAddress(address);
+        user.setFirstName(firstName);
+        user.setFirstName(lastName);
+        return user;
+    }
+
+    private void checkEmail(int index, String expectedEmail,
+            EmailType expectedType) {
         assertEquals(expectedEmail,
                 sendedMails.get(index).getInstance().getEmail());
 
-        assertEquals(expectedType,
-                sendedMails.get(index).getEmailType());
+        assertEquals(expectedType, sendedMails.get(index).getEmailType());
 
         assertNull(sendedMails.get(index).getParams());
     }
@@ -3202,9 +3318,8 @@ public class IdentityServiceBeanIT extends EJBTestBase {
     }
 
     private List<RoleAssignment> getRoleAssignmentByUserKey(long key) {
-        return ParameterizedTypes.list(mgr
-                .createQuery(
-                        "SELECT o FROM RoleAssignment o WHERE o.user.key = :userKey")
+        return ParameterizedTypes.list(mgr.createQuery(
+                "SELECT o FROM RoleAssignment o WHERE o.user.key = :userKey")
                 .setParameter("userKey", Long.valueOf(key)).getResultList(),
                 RoleAssignment.class);
     }

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
@@ -395,11 +395,9 @@ public class IdentityServiceBean
                         TriggerProcessParameterName.MARKETPLACE_ID)
                 .getValue(String.class);
         Map<Long, UnitUserRole> userGroupKeyToRole = ParameterizedTypes
-                .hashmap(
-                        tp.getParamValueForName(
-                                TriggerProcessParameterName.USER_GROUPS_WITH_ROLES)
-                                .getValue(Map.class),
-                        Long.class, UnitUserRole.class);
+                .hashmap(tp.getParamValueForName(
+                        TriggerProcessParameterName.USER_GROUPS_WITH_ROLES)
+                        .getValue(Map.class), Long.class, UnitUserRole.class);
 
         // generate a one-time password for the user
         VOUserDetails result;
@@ -904,7 +902,8 @@ public class IdentityServiceBean
         PermissionCheck.sameOrg(dm.getCurrentUser(), existingUser, logger);
 
         PlatformUser oldUser = existingUser.getEmail() != null
-                ? UserDataAssembler.copyPlatformUser(existingUser) : null;
+                ? UserDataAssembler.copyPlatformUser(existingUser)
+                : null;
 
         // validate permissions for the call, administrator may change any user,
         // a non administrator may only change his own account
@@ -1002,6 +1001,10 @@ public class IdentityServiceBean
             platformUsers.add(oldUser);
         }
 
+        long ch1 = UserChecksum.of(existingUser);
+        long ch2 = UserChecksum.of(oldUser);
+        if (ch1 == ch2)
+            return;
         SendMailStatus<PlatformUser> mailStatus = cm.sendMail(
                 EmailType.USER_UPDATED, null, null,
                 platformUsers.toArray(new PlatformUser[platformUsers.size()]));
@@ -1568,12 +1571,14 @@ public class IdentityServiceBean
             if (!organizationAdmin.hasManagerRole()) {
                 url.append("/marketplace/confirm.jsf?")
                         .append((marketplaceId != null)
-                                ? "mId=" + marketplaceId + "&" : "")
+                                ? "mId=" + marketplaceId + "&"
+                                : "")
                         .append("enc=");
             } else {
                 url.append("/public/confirm.jsf?")
                         .append((marketplaceId != null)
-                                ? "mId=" + marketplaceId + "&" : "")
+                                ? "mId=" + marketplaceId + "&"
+                                : "")
                         .append("enc=");
             }
 

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
@@ -902,7 +902,7 @@ public class IdentityServiceBean
         PermissionCheck.sameOrg(dm.getCurrentUser(), existingUser, logger);
 
         PlatformUser oldUser = existingUser.getEmail() != null
-                ? UserDataAssembler.copyPlatformUser(existingUser)
+                ? UserDataAssembler.copyPlatformUserWithRoles(existingUser)
                 : null;
 
         // validate permissions for the call, administrator may change any user,

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
@@ -901,6 +901,7 @@ public class IdentityServiceBean
         // check whether user belongs to same organization than the caller
         PermissionCheck.sameOrg(dm.getCurrentUser(), existingUser, logger);
 
+        //TODO avoid null by using factory pattern  
         PlatformUser oldUser = existingUser.getEmail() != null
                 ? UserDataAssembler.copyPlatformUserWithRoles(existingUser)
                 : null;

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/IdentityServiceBean.java
@@ -1005,6 +1005,7 @@ public class IdentityServiceBean
         long ch2 = UserChecksum.of(oldUser);
         if (ch1 == ch2)
             return;
+        
         SendMailStatus<PlatformUser> mailStatus = cm.sendMail(
                 EmailType.USER_UPDATED, null, null,
                 platformUsers.toArray(new PlatformUser[platformUsers.size()]));

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
@@ -22,12 +22,22 @@ import org.oscm.domobjects.RoleAssignment;
 class UserChecksum {
 
     static long of(PlatformUser pUser) {
+
+        // TODO avoid with factory
+        if (pUser == null) {
+            return of("null");
+        }
         StringBuffer sb = new StringBuffer();
         sb.append(pUser.getUserId() + ",");
         sb.append(pUser.getEmail() + ",");
+        if (pUser.getSalutation() != null)
+            sb.append(pUser.getSalutation().name() + ",");
         sb.append(pUser.getFirstName() + ",");
         sb.append(pUser.getLastName() + ",");
+        sb.append(pUser.getRealmUserId() + ",");
         sb.append(pUser.getLocale() + ",");
+        sb.append(pUser.getAddress() + ",");
+        sb.append(pUser.getPhone() + ",");
         sb.append(pUser.getTenantId() + ",");
 
         Iterator<RoleAssignment> roleIterator = pUser.getAssignedRoles()

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *                                                                              
+ *  Copyright FUJITSU LIMITED 2019                                           
+ *                                                                                                                                 
+ *  Creation Date: 16.01.2019                                                      
+ *                                                                              
+ *******************************************************************************/
+
+package org.oscm.identityservice.bean;
+
+import java.util.Iterator;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+import org.oscm.domobjects.PlatformUser;
+import org.oscm.domobjects.RoleAssignment;
+
+/**
+ * @author goebel
+ *
+ */
+class UserChecksum {
+
+    static long of(PlatformUser pUser) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(pUser.getUserId() + ",");
+        sb.append(pUser.getEmail() + ",");
+        sb.append(pUser.getFirstName() + ",");
+        sb.append(pUser.getLastName() + ",");
+        sb.append(pUser.getLocale() + ",");
+        sb.append(pUser.getTenantId() + ",");
+
+        Iterator<RoleAssignment> roleIterator = pUser.getAssignedRoles()
+                .iterator();
+        while (roleIterator.hasNext()) {
+            RoleAssignment roleAssignment = roleIterator.next();
+            String r = roleAssignment.getRole().getRoleName().toString();
+            sb.append(r + ",");
+        }
+        String user = sb.toString();
+        return of(user);
+    }
+
+    static long of(String input) {
+        byte bytes[] = input.getBytes();
+        Checksum checksum = new CRC32();
+        checksum.update(bytes, 0, bytes.length);
+        return checksum.getValue();
+    }
+}

--- a/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
+++ b/oscm-identitymgmt/javasrc/org/oscm/identityservice/bean/UserChecksum.java
@@ -34,7 +34,6 @@ class UserChecksum {
             sb.append(pUser.getSalutation().name() + ",");
         sb.append(pUser.getFirstName() + ",");
         sb.append(pUser.getLastName() + ",");
-        sb.append(pUser.getRealmUserId() + ",");
         sb.append(pUser.getLocale() + ",");
         sb.append(pUser.getAddress() + ",");
         sb.append(pUser.getPhone() + ",");

--- a/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
+++ b/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
@@ -156,6 +156,9 @@ public class UserServiceBean implements UserService {
             
             updateUserAndRoles(user, existing);
 
+            ds.flush();
+            ds.refresh(existing);
+            
             // notify subscriptions
             isl.notifySubscriptionsAboutUserUpdate(existing);
 
@@ -333,6 +336,9 @@ public class UserServiceBean implements UserService {
             // update user data and roles
             updateUserAndRoles(user, existing);
 
+            ds.flush();
+            ds.refresh(existing);
+            
             updateUserGroups(groupsToBeAssigned, user, existing);
             List<UsageLicense> assignments = slsl.getSubscriptionAssignments(
                     existing, Subscription.ASSIGNABLE_SUBSCRIPTION_STATUS);

--- a/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
+++ b/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
@@ -152,8 +152,8 @@ public class UserServiceBean implements UserService {
 
             // keep a reference (not managed) with the old email
             PlatformUser old = existing.getEmail() != null ? UserDataAssembler
-                    .copyPlatformUser(existing) : null;
-
+                    .copyPlatformUserWithRoles(existing) : null;
+            
             updateUserAndRoles(user, existing);
 
             // notify subscriptions

--- a/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
+++ b/oscm-internal/javasrc/org/oscm/internal/usermanagement/UserServiceBean.java
@@ -328,7 +328,7 @@ public class UserServiceBean implements UserService {
                     user.getKey());
             // keep a reference (not managed) with the old email
             PlatformUser old = existing.getEmail() != null ? UserDataAssembler
-                    .copyPlatformUser(existing) : null;
+                    .copyPlatformUserWithRoles(existing) : null;
 
             // update user data and roles
             updateUserAndRoles(user, existing);


### PR DESCRIPTION
Avoid account change emails being issued when saving unmodified user data

* **UserServiceBean#saveUser**
    
     - include role assignments for copied user and 
     - refresh user after modification to ensure complete and  fresh user data is passed to _IdentityServiceLocal#sendUserUpdatedMail_ (both required for comparisons)

* **UserServiceBean#saveUserAndSubscriptionAssignment** 
    
     - include role assignments for copied user and 
     - refresh user after modification to ensure complete and  fresh user data is passed to _IdentityServiceLocal#sendUserUpdatedMail_ (both required for comparisons)

* **IdentityServiceLocal#sendUserUpdatedMail**
    - compute checksum of updated existing user 
    - compute checksum of old user 
    - compare and 
               - return, if both equal (nothing changed)
               - process as before sending account change email, if not equal (user data modified)
